### PR TITLE
Slight changes to pod tests

### DIFF
--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -1,2 +1,9 @@
-use Test::Pod::Coverage tests=>1;
-pod_coverage_ok( "WWW::Salesforce", "WWW::Salesforce is covered" );
+use strict;
+use Test::More;
+use Test::Pod::Coverage;
+
+plan skip_all => 'set TEST_POD to enable this test (developer only!)'
+        unless $ENV{TEST_POD};
+
+plan tests => 1;
+pod_coverage_ok( "ITI::Paycor" );

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -6,4 +6,4 @@ plan skip_all => 'set TEST_POD to enable this test (developer only!)'
         unless $ENV{TEST_POD};
 
 plan tests => 1;
-pod_coverage_ok( "ITI::Paycor" );
+pod_coverage_ok( "WWW::Salesforce" );

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,4 +1,8 @@
+use strict;
 use Test::More;
-eval "use Test::Pod 1.00";
-plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;
+use Test::Pod;
+
+plan skip_all => 'set TEST_POD to enable this test (developer only!)'
+        unless $ENV{TEST_POD};
+
 all_pod_files_ok();


### PR DESCRIPTION
Again, apologies for the mixup.  The pod tests should only be run when requested as userland won't care about those so much.

For instance: 

```bash
export TEST_POD=1
make test
```
