### PR TITLE
Update the API endpoint to login.salesforce.com

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension WWW::Salesforce.
 
+0.25 Nov 12 2015
+    - change login URL from www.salesforce.com to login.salesforce.com 
+      - www.salesforce.com will no longer be an API login endpoint as of Jan 1 2016
+
 0.24 Aug 1 2015
     - https://github.com/redhotpenguin/WWW-Salesforce/pull/20
 

--- a/Changes
+++ b/Changes
@@ -1,7 +1,7 @@
 Revision history for Perl extension WWW::Salesforce.
 
 0.25 Nov 12 2015
-    - change login URL from www.salesforce.com to login.salesforce.com 
+    - change login URL from www.salesforce.com to login.salesforce.com [github/dclendenan]
       - www.salesforce.com will no longer be an API login endpoint as of Jan 1 2016
 
 0.24 Aug 1 2015

--- a/lib/WWW/Salesforce.pm
+++ b/lib/WWW/Salesforce.pm
@@ -15,9 +15,9 @@ use vars qw(
   $VERSION $SF_URI $SF_PREFIX $SF_PROXY $SF_SOBJECT_URI $SF_URIM $SF_APIVERSION $WEB_PROXY
 );
 
-$VERSION = '0.24';
+$VERSION = '0.25';
 
-$SF_PROXY       = 'https://www.salesforce.com/services/Soap/u/8.0';
+$SF_PROXY       = 'https://login.salesforce.com/services/Soap/u/8.0';
 $SF_URI         = 'urn:partner.soap.sforce.com';
 $SF_PREFIX      = 'sforce';
 $SF_SOBJECT_URI = 'urn:sobject.partner.soap.sforce.com';


### PR DESCRIPTION
API calls to www.salesforce.com will no longer be supported as of 1/1/2016. The end-point all customers should be using is login.salesforce.com.